### PR TITLE
Remove manual node_modules/* invocation from npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "description": "Rackspace Canon components built with React",
   "scripts": {
-    "build": "./node_modules/.bin/grunt build",
-    "demo-build": "./node_modules/.bin/grunt demo-build",
-    "test-watch": "./node_modules/.bin/grunt watch 2>&1 >/dev/null & ./node_modules/karma/bin/karma start karma.dev.js",
-    "test": "./node_modules/.bin/grunt build && ./node_modules/karma/bin/karma start karma.ci.js"
+    "build": "grunt build",
+    "demo-build": "grunt demo-build",
+    "test-watch": "grunt watch 2>&1 >/dev/null & karma start karma.dev.js",
+    "test": "grunt build && karma start karma.ci.js"
   },
   "keywords": [
     "react",


### PR DESCRIPTION
npm scripts automatically include node_modules/.bin in their path:
http://substack.net/task_automation_with_npm_run

```
canon-react acoppa$ which grunt
canon-react acoppa$

canon-react acoppa$ npm run build

> canon-react@0.1.0 build /Users/acoppa/canon-react
> grunt build

Running "clean:test" (clean) task
Cleaning test-built...OK

[...]

Done, without errors.
```
